### PR TITLE
Send Bid Feature Improvements

### DIFF
--- a/bottracker.html
+++ b/bottracker.html
@@ -34,7 +34,8 @@
 
     <script src="https://cdn.steemjs.com/lib/latest/steem.min.js"></script>
 
-    <script src="scripts/bottracker.min.js?v=16"></script>
+    <script src="scripts/utils.js"></script>
+    <script src="scripts/bottracker.js"></script>
 
     <script type="text/javascript">
         steem.api.setOptions({ url: 'https://api.steemit.com' });

--- a/bottracker.html
+++ b/bottracker.html
@@ -34,7 +34,8 @@
 
     <script src="https://cdn.steemjs.com/lib/latest/steem.min.js"></script>
 
-    <script src="scripts/utils.js"></script>
+    <!-- This will go back to the bottracker.min.js before the PR is merged -->
+    <script src="scripts/utils.js"></script> 
     <script src="scripts/bottracker.js"></script>
 
     <script type="text/javascript">
@@ -766,6 +767,11 @@
             <div class="form-group">
               <label for="bid_details_post_url">Your post URL</label>
               <input type="url" class="form-control" id="bid_details_post_url" placeholder="Post URL">
+            </div>
+
+            <div class="form-group">
+              <label for="bid_details_post_url">Your Recent Posts</label>
+              <span id="bid_details_recent_posts">None Found</span>
             </div>
 
             <div class="alert alert-danger" id="bid_details_error"></div>

--- a/scripts/bottracker.js
+++ b/scripts/bottracker.js
@@ -751,6 +751,8 @@ $(function () {
       $('#bid_details_error').hide();
       $('#bid_details_btn_submit').click(submitBid);
       $('#bid_details_post_url').val('');
+      $('#bid_details_bid_amount').val(bot.min_bid)
+      $('#bid_details_bid_amount').attr("min", bot.min_bid);
       _dialog = $('#bid_details_dialog').modal();
       _dialog.off('hidden.bs.modal');
       _dialog.bot = bot;

--- a/scripts/bottracker.js
+++ b/scripts/bottracker.js
@@ -808,6 +808,15 @@ $(function () {
 
     $('#min_vote_slider').slider();
 
+    //remember Steemit username
+    if (localStorage.hasOwnProperty('bid_details_account_name')) {
+      $('#bid_details_account_name').val(localStorage.getItem('bid_details_account_name'));
+    }
+
+    $('#bid_details_account_name').on("change", function(e) {
+      localStorage.setItem('bid_details_account_name', $('#bid_details_account_name').val())
+    });
+
     //remember slider choice
     if (!localStorage.hasOwnProperty('min_vote_slider')) {
       localStorage.setItem('min_vote_slider', 0);


### PR DESCRIPTION
# Send Bid Feature Improvements
This PR implements several Send Bid feature improvements as described in [this](https://utopian.io/utopian-io/@maxg/steem-bot-tracker-improve-send-bid-feature) Utopian.io Suggestion Post.

#### Improvements:
1. Save username in localStorage 
2. Set default content of `bid_details_bid_amount` text input according to `bot.min_bid` value
3. Provide suggestions by pulling from recent posts made by that user
   - Only posts less than 1 week old are displayed

#### Screenshot for 3:
![](https://steemitimages.com/DQmScTazYvBX5VT8fPqAKqTqAN3qAAPgtfmeB2NoTaZA7RA/image.png)

## Note:
I have not minified the new `bottracker.js` and the `bottracker.html` currently pulls the non-minified version. As soon as I figure out the preferred way to do this, I'll add a new commit to this PR.

---
For Utopian.io Verification Purposes my username is [@maxg](https://utopian.io/@maxg)