### PR TITLE
Fixed bug after the inclusion of Maximum ROI limit feature at postpromoter bot.

### DIFF
--- a/scripts/bottracker.js
+++ b/scripts/bottracker.js
@@ -8,7 +8,7 @@ $(function () {
     var other_bots = [];
     var FULL_CURATION_TIME = 30 * 60 * 1000;
 
-    $.get('https://www.brupvoter.com/bottracker/bidbots.json', function (data) {
+    $.get('https://steembottracker.com/bidbots.json', function (data) {
       bots = data;
 
       bots.sort(function(a, b){

--- a/scripts/bottracker.js
+++ b/scripts/bottracker.js
@@ -668,8 +668,14 @@ $(function () {
         if (bot.rounds && bot.rounds.length > 1) {
           var round = bot.rounds[bot.rounds.length - 2];
           var weight = sumWeights(round);
+	  var last_vote = ((weight/100) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney();
+          if(CURRENCY == 'SBD' || CURRENCY == 'STEEM')
+            last_vote = last_vote + ' ' + CURRENCY;
+          else
+            last_vote = '$' + last_vote;
+
           populateRoundDetailTable(last_table, bot, round, 1);
-          $('#last_round_vote').text(((weight/100) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney() + ' (' + weight.formatMoney() + '%)');
+          $('#last_round_vote').text(last_vote + ' (' + weight.formatMoney() + '%)');
           $('#last_round_bids').text(sumBids(round, 'SBD').formatMoney() + ' SBD' + (bot.accepts_steem ? ' & ' + sumBids(round, 'STEEM').formatMoney() + ' STEEM' : ''));
           $('#last_round_value').text('$' + round.total_usd.formatMoney());
           $('#last_round_roi').text((((bot.vote_usd * AUTHOR_REWARDS * (weight / 100) / round.total_usd) - 1) * 100).formatMoney() + '% (After Curation)');

--- a/scripts/bottracker.js
+++ b/scripts/bottracker.js
@@ -668,7 +668,7 @@ $(function () {
         if (bot.rounds && bot.rounds.length > 1) {
           var round = bot.rounds[bot.rounds.length - 2];
           var weight = sumWeights(round);
-	  var last_vote = ((weight/100) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney();
+          var last_vote = ((weight/100) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney();
           if(CURRENCY == 'SBD' || CURRENCY == 'STEEM')
             last_vote = last_vote + ' ' + CURRENCY;
           else

--- a/scripts/bottracker.js
+++ b/scripts/bottracker.js
@@ -8,7 +8,7 @@ $(function () {
     var other_bots = [];
     var FULL_CURATION_TIME = 30 * 60 * 1000;
 
-    $.get('https://steembottracker.com/bidbots.json', function (data) {
+    $.get('https://www.brupvoter.com/bottracker/bidbots.json', function (data) {
       bots = data;
 
       bots.sort(function(a, b){
@@ -632,6 +632,12 @@ $(function () {
       }
     }
 
+    function sumWeights(round) {
+      return round.bids.reduce(function(total, bid) {
+          return total + parseFloat(bid.data.weight)/100;
+      }, 0);
+    }
+
     function sumBids(round, currency) {
       return round.bids.reduce(function(total, bid) {
         if(getCurrency(bid.data.amount) == currency)
@@ -651,7 +657,7 @@ $(function () {
 
         if (bot.rounds && bot.rounds.length > 0) {
           var round = bot.rounds[bot.rounds.length - 1];
-          populateRoundDetailTable(cur_table, bot, round);
+          populateRoundDetailTable(cur_table, bot, round, 0);
 
           $('#cur_round_vote').text(formatCurrencyVote(bot) + ' (' + (bot.interval / 2.4 * 100) + '%)');
           $('#cur_round_bids').text(sumBids(round, 'SBD').formatMoney() + ' SBD' + (bot.accepts_steem ? ' & ' + sumBids(round, 'STEEM').formatMoney() + ' STEEM' : ''));
@@ -661,11 +667,12 @@ $(function () {
 
         if (bot.rounds && bot.rounds.length > 1) {
           var round = bot.rounds[bot.rounds.length - 2];
-          populateRoundDetailTable(last_table, bot, round);
-          $('#last_round_vote').text(formatCurrencyVote(bot) + ' (' + (bot.interval / 2.4 * 100) + '%)');
+          var weight = sumWeights(round);
+          populateRoundDetailTable(last_table, bot, round, 1);
+          $('#last_round_vote').text(((weight/100) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney() + ' (' + weight.formatMoney() + '%)');
           $('#last_round_bids').text(sumBids(round, 'SBD').formatMoney() + ' SBD' + (bot.accepts_steem ? ' & ' + sumBids(round, 'STEEM').formatMoney() + ' STEEM' : ''));
           $('#last_round_value').text('$' + round.total_usd.formatMoney());
-          $('#last_round_roi').text((((bot.vote_usd * AUTHOR_REWARDS / round.total_usd) - 1) * 100).formatMoney() + '% (After Curation)');
+          $('#last_round_roi').text((((bot.vote_usd * AUTHOR_REWARDS * (weight / 100) / round.total_usd) - 1) * 100).formatMoney() + '% (After Curation)');
         }
 
         $('#cur_round_show').click(function (e) {
@@ -685,7 +692,7 @@ $(function () {
         $('#bid_details').modal();
     }
 
-    function populateRoundDetailTable(table, bot, round) {
+    function populateRoundDetailTable(table, bot, round, weight) {
         round.bids.forEach(function (bid) {
             var amount = parseFloat(bid.data.amount);
             var bid_value = getUsdValue(bid.data);
@@ -718,11 +725,17 @@ $(function () {
             row.append(td);
 
             var td = $(document.createElement('td'));
-            td.text((bid_value / round.total_usd * 100).formatMoney() + '%');
-            td.css('text-align', 'right');
-            row.append(td);
-
-            var value = ((bid_value / round.total_usd) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney();
+            if(weight) {
+              td.text((bid.data.weight / 100).formatMoney() + '%');
+              td.css('text-align', 'right');
+              row.append(td);
+              var value = ((bid.data.weight / 10000) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney();
+            } else {
+              td.text((bid_value / round.total_usd * 100).formatMoney() + '%');
+              td.css('text-align', 'right');
+              row.append(td);
+              var value = ((bid_value / round.total_usd) * parseFloat(formatCurrencyVote(bot).replace(/[$,]/g, ''))).formatMoney();
+            }
 
             if(CURRENCY == 'SBD' || CURRENCY == 'STEEM')
               value = value + ' ' + CURRENCY;


### PR DESCRIPTION
BUG: Bottracker ever shows a voting share with 100% weight, even when we limit the round ROI in (MAX_ROI %). That is not always correct, because when we limit the MAX_ROI and at the end of the round the ROI is greater than MAX_ROI the bot will decrease its vote value weight to make ROI=MAX_ROI.  So the bot will share a vote with a weight that is less than 100%.
This commit fixes this bug. Now. it shows the correct information about voting weight and voting value at "Last Round" tab from "Bidding Round Details" window.
