### PR TITLE
Bugfix/bitwise ops sometimes return negatives

### DIFF
--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -448,7 +448,9 @@
     
     //Functions for Approx SQRT (see https://github.com/steemit/steem/blob/5c787c5baa651858658caa2bd47473846b099c0a/doc/sqrt.md)
     function approx_sqrt(x){
-      if(x == 0) return 0;
+      // we don't want to let the code aproximate sqrts from negative inputs..
+      if(x <= 0) return 0;
+
       var msb_x = find_msb(x);
       var msb_z = msb_x >> 1;
   

--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -493,19 +493,12 @@
     }
 
     function shiftleft64(x,y){
-      x = hi_lo(x);  
-      hi = x.hi * Math.pow(2,y);
-      lo = x.lo * Math.pow(2,y);
-      return hi*Math.pow(2,32) + lo;
+      return (x * Math.pow(2,y)) % Math.pow(2,64); // mod64 as a safeguard against 'val' exceeding 64bit integer range
     }
 
     function shiftright64(x,y){
-      x = hi_lo(x);
-      hi = Math.floor(x.hi / Math.pow(2,y));
-      aux = x.hi % Math.pow(2,y);
-      lo = Math.floor(x.lo / Math.pow(2,y)) + aux * Math.pow(2,32-y);
-      return hi*Math.pow(2,32) + lo;
-    }   
+      return Math.floor(x / Math.pow(2,y));
+    }
   </script>
 
   <script type="text/javascript">

--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -469,10 +469,13 @@
       return Math.floor(Math.log(x)/Math.log(2));
     }
 
+    const BIT32_LIMIT = Math.pow(2,32);
+    const BIT64_LIMIT = Math.pow(2,64);
+
     function hi_lo(x){
       r = {};
-      r.hi = Math.floor(x / Math.pow(2,32));
-      r.lo = x % Math.pow(2,32);
+      r.hi = Math.floor(x / BIT32_LIMIT);
+      r.lo = x % BIT32_LIMIT;
       return r;  
     }
 
@@ -481,7 +484,7 @@
       y = hi_lo(y);
       hi = (x.hi & y.hi) >>> 0;
       lo = (x.lo & y.lo) >>> 0;
-      return hi*Math.pow(2,32) + lo;
+      return hi*BIT32_LIMIT + lo;
     }
 
     function or64(x,y){
@@ -489,11 +492,11 @@
       y = hi_lo(y);
       hi = (x.hi | y.hi) >>> 0;
       lo = (x.lo | y.lo) >>> 0;
-      return hi*Math.pow(2,32) + lo;
+      return hi*BIT32_LIMIT + lo;
     }
 
     function shiftleft64(x,y){
-      return (x * Math.pow(2,y)) % Math.pow(2,64); // mod64 as a safeguard against 'val' exceeding 64bit integer range
+      return (x * Math.pow(2,y)) % BIT64_LIMIT; // mod64 as a safeguard against 'val' exceeding 64bit integer range
     }
 
     function shiftright64(x,y){

--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -507,5 +507,176 @@
       return hi*Math.pow(2,32) + lo;
     }   
   </script>
+
+  <script type="text/javascript">
+    // some simple tests for bitwise ops
+    var Tests = {};
+
+    Tests.hi_lo = {
+      low: () => {
+        var hl = hi_lo(1078);
+        if(bin64(hl.hi) != '0000000000000000000000000000000000000000000000000000000000000000') return "failed: hi";
+        if(bin64(hl.lo) != '0000000000000000000000000000000000000000000000000000010000110110') return "failed: lo";
+        return true;
+      },
+      high: () => {
+        var hl = hi_lo(17179869182);
+        if(bin64(hl.hi) != '0000000000000000000000000000000000000000000000000000000000000011') return "failed: hi";
+        if(bin64(hl.lo) != '0000000000000000000000000000000011111111111111111111111111111110') return "failed: lo";
+        return true;
+      },
+    };
+
+    Tests.and64 = {
+      low: () => {
+        // 2nd arg: 32bitmask, all '1', bitvalue shouldn't change
+        var val = and64(1078,4294967295);
+        if(bin64(val) != '0000000000000000000000000000000000000000000000000000010000110110') return "failed";
+        return true;
+      },
+      high: () => {
+        // 2nd arg: 36bitmask, all '1', bitvalue shouldn't change
+        var val = and64(17179869182,4294967295*16+15);
+        if(bin64(val) != '0000000000000000000000000000001111111111111111111111111111111110') return "failed";
+        return true;
+      },
+    };
+
+    Tests.or64 = {
+      low: () => {
+        // 2nd arg: all '0', bitvalue shouldn't change
+        var val = or64(1078,0);
+        if(bin64(val) != '0000000000000000000000000000000000000000000000000000010000110110') return "failed";
+        return true;
+      },
+      high: () => {
+        // 2nd arg: all '0', bitvalue shouldn't change
+        var val = or64(17179869182,0);
+        if(bin64(val) != '0000000000000000000000000000001111111111111111111111111111111110') return "failed";
+        return true;
+      },
+    };
+
+    Tests.shiftleft64 = {
+      low: () => {
+        var val = shiftleft64(1078,16);
+        if(bin64(val) != '0000000000000000000000000000000000000100001101100000000000000000') return "failed";
+        return true;
+      },
+      low_almostlastbit: () => {
+        var val = shiftleft64(1078,52);
+        if(bin64(val) != '0100001101100000000000000000000000000000000000000000000000000000') return "failed";
+        return true;
+      },
+      low_lastbit: () => {
+        var val = shiftleft64(1078,53);
+        if(bin64(val) != '1000011011000000000000000000000000000000000000000000000000000000') return "failed";
+        return true;
+      },
+      low_overflow: () => {
+        var val = shiftleft64(1078,54);
+        if(bin64(val) != '0000110110000000000000000000000000000000000000000000000000000000') return "failed";
+        return true;
+      },
+
+      high: () => {
+        var val = shiftleft64(17179869182,16);
+        if(bin64(val) != '0000000000000011111111111111111111111111111111100000000000000000') return "failed";
+        return true;
+      },
+      high_almostlastbit: () => {
+        var val = shiftleft64(17179869182,29);
+        if(bin64(val) != '0111111111111111111111111111111111000000000000000000000000000000') return "failed";
+        return true;
+      },
+      high_lastbit: () => {
+        var val = shiftleft64(17179869182,30);
+        if(bin64(val) != '1111111111111111111111111111111110000000000000000000000000000000') return "failed";
+        return true;
+      },
+      high_overflow: () => {
+        var val = shiftleft64(17179869182,31);
+        if(bin64(val) != '1111111111111111111111111111111100000000000000000000000000000000') return "failed";
+        return true;
+      },
+    };
+
+    Tests.shiftright64 = {
+      // shiftright64 should be inverse of shiftleft64, except for cases when shiftleft64 overflows
+      low: () => {
+        var val = shiftright64(parseInt('0000000000000000000000000000000000000100001101100000000000000000',2),16);
+        if(val != 1078) return "failed";
+        return true;
+      },
+      low_almostlastbit: () => {
+        var val = shiftright64(parseInt('0100001101100000000000000000000000000000000000000000000000000000',2),52);
+        if(val != 1078) return "failed";
+        return true;
+      },
+      // in our case, shiftright64 should never return negatives,
+      // even if MSB of the input is set and input value could look like a negative
+      low_lastbit: () => {
+        var val = shiftright64(parseInt('1000011011000000000000000000000000000000000000000000000000000000',2),53);
+        if(val != 1078) return "failed";
+        return true;
+      },
+
+      high: () => {
+        var val = shiftright64(parseInt('0000000000000011111111111111111111111111111111100000000000000000',2),16);
+        if(val != 17179869182) return "failed";
+        return true;
+      },
+      high_almostlastbit: () => {
+        var val = shiftright64(parseInt('0111111111111111111111111111111111000000000000000000000000000000',2),29);
+        if(val != 17179869182) return "failed";
+        return true;
+      },
+      // in our case, shiftright64 should never return negatives,
+      // even if MSB of the input is set and input value could look like a negative
+      high_lastbit: () => {
+        var val = shiftright64(parseInt('1111111111111111111111111111111110000000000000000000000000000000',2),30);
+        if(val != 17179869182) return "failed";
+        return true;
+      },
+    };
+
+    /*
+      results before patch, original code gitrev:514d9bb6ed6c9a07c4e595947ab71fe424a49845
+      On: Google Chrome 69.0.3497.100, Windows 10 x64
+        and64: high: failed
+        or64: high: failed
+        shiftleft64: low: failed
+        shiftleft64: low_overflow: failed
+        shiftleft64: high_overflow: failed
+        shiftright64: low: failed
+        Failed 6/20 tests
+    */
+
+    // FYI: doing that this way will have funny effects if 'n' is negative (i.e. -7 = '0000000000-111')
+    // but we don't care - 'n' should be positive and any funny effects will fail the test so it's OK
+    function bin64(n) {
+      return n.toString(2).padStart(64,'0');
+    }
+
+    // right now, I don't want to make fuss and install Jasmine/etc, so here's my quick'n'dirty test runner
+    function runTests(suite) {
+      var testlist = Object.keys(Tests).map(k => Object.keys(Tests[k]).map(k2 => ({outer:k,inner:k2})));
+      testlist = testlist.flat();
+      var results = testlist.map(what => {
+        var result = suite[what.outer][what.inner]();
+        if(result === true) return [true, what.outer, what.inner, null];
+        console.log(what.outer + ": " + what.inner + ": " + result);
+        return [false, what.outer, what.inner, result];
+      });
+      var countfailed = results.filter(arr => !arr[0]).length;
+      if(countfailed > 0) {
+        console.log("Failed " + countfailed + "/" + results.length + " tests");
+        return false;
+      }
+      else
+        return true;
+    }
+
+    </script>
 </body>
 </html>

--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -508,6 +508,9 @@
 
   <script type="text/javascript">
     // some simple tests for bitwise ops
+    // run it in the browser console for example by:
+    //   runTests(Tests);
+
     var Tests = {};
 
     Tests.hi_lo = {

--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -479,16 +479,16 @@
     function and64(x,y){
       x = hi_lo(x);
       y = hi_lo(y);
-      hi = x.hi & y.hi;
-      lo = x.lo & y.lo;
+      hi = (x.hi & y.hi) >>> 0;
+      lo = (x.lo & y.lo) >>> 0;
       return hi*Math.pow(2,32) + lo;
     }
 
     function or64(x,y){
       x = hi_lo(x);
       y = hi_lo(y);
-      hi = x.hi | y.hi;
-      lo = x.lo | y.lo;
+      hi = (x.hi | y.hi) >>> 0;
+      lo = (x.lo | y.lo) >>> 0;
       return hi*Math.pow(2,32) + lo;
     }
 

--- a/curation_calculator.html
+++ b/curation_calculator.html
@@ -449,18 +449,18 @@
     //Functions for Approx SQRT (see https://github.com/steemit/steem/blob/5c787c5baa651858658caa2bd47473846b099c0a/doc/sqrt.md)
     function approx_sqrt(x){
       if(x == 0) return 0;
-      msb_x = find_msb(x);
-      msb_z = msb_x >> 1;
+      var msb_x = find_msb(x);
+      var msb_z = msb_x >> 1;
   
-      msb_x_bit = shiftleft64(1,msb_x);
-      msb_z_bit = shiftleft64(1,msb_z);
+      var msb_x_bit = shiftleft64(1,msb_x);
+      var msb_z_bit = shiftleft64(1,msb_z);
   
-      mantissa_mask = msb_x_bit - 1;
-      mantissa_x = and64(x,mantissa_mask);
-      mantissa_z_hi = and64(msb_x,1) ? msb_z_bit : 0;
-      mantissa_z_lo = shiftright64(mantissa_x , msb_x - msb_z);
-      mantissa_z = shiftright64(or64(mantissa_z_hi , mantissa_z_lo) , 1);
-      result = or64(msb_z_bit , mantissa_z);
+      var mantissa_mask = msb_x_bit - 1;
+      var mantissa_x = and64(x,mantissa_mask);
+      var mantissa_z_hi = and64(msb_x,1) ? msb_z_bit : 0;
+      var mantissa_z_lo = shiftright64(mantissa_x , msb_x - msb_z);
+      var mantissa_z = shiftright64(or64(mantissa_z_hi , mantissa_z_lo) , 1);
+      var result = or64(msb_z_bit , mantissa_z);
       
       return result;
     }
@@ -473,7 +473,7 @@
     const BIT64_LIMIT = Math.pow(2,64);
 
     function hi_lo(x){
-      r = {};
+      var r = {};
       r.hi = Math.floor(x / BIT32_LIMIT);
       r.lo = x % BIT32_LIMIT;
       return r;  
@@ -482,16 +482,16 @@
     function and64(x,y){
       x = hi_lo(x);
       y = hi_lo(y);
-      hi = (x.hi & y.hi) >>> 0;
-      lo = (x.lo & y.lo) >>> 0;
+      var hi = (x.hi & y.hi) >>> 0;
+      var lo = (x.lo & y.lo) >>> 0;
       return hi*BIT32_LIMIT + lo;
     }
 
     function or64(x,y){
       x = hi_lo(x);
       y = hi_lo(y);
-      hi = (x.hi | y.hi) >>> 0;
-      lo = (x.lo | y.lo) >>> 0;
+      var hi = (x.hi | y.hi) >>> 0;
+      var lo = (x.lo | y.lo) >>> 0;
       return hi*BIT32_LIMIT + lo;
     }
 


### PR DESCRIPTION
This pull-request corrects some issues introduced during commit "calculation using weights and approx_sqrt" (sha:  9077ef6aef39359dc02b2166adf7a4663ddb42ed).

Original work from @joticajulian aimed on close(r) reproduction of inexact sqrt algorithm used in steem blockchain. To be honest, I didn't check, but it looks like translating C/C++ code into JS, and some subtle bugs creeped in: the 'integer' type and bitwise ops in JS work a little bit different than in C/C++, namely:

- all bitwise ops (except for >>>) return signed values (hence wrong results were produced during `+` when hi/lo were merged back into one),
- there is no true integer, it's all 64bit floats (so there's no sense in hi/lo'ing during shiftleft/right - just multiply or divide via Math.pow in one go)

This pull-request also contains some 'unit tests' (at the end of the code). Run them against unmodified and/or/shift to see what's wrong.

All of these tests pass just fine on patched code, but the tests are not exhaustive. I aimed to fix the negative results, which greatly damaged the overall result. Other subtle issues still occur after patching, because the attempt to mimic 64-bit integer and/or/shift is leaky: in JS the numeric type is 64bit float, not integer, so while **numerical range** is covered, the **bitwise range** is not covered. See for example:

```
(Math.pow(2,64)-0).toString(2)
"10000000000000000000000000000000000000000000000000000000000000000"
(Math.pow(2,64)-1023).toString(2)
"10000000000000000000000000000000000000000000000000000000000000000"
(Math.pow(2,64)-1024).toString(2)
"10000000000000000000000000000000000000000000000000000000000000000"
(Math.pow(2,64)-1025).toString(2)
"1111111111111111111111111111111111111111111111111111100000000000"
(Math.pow(2,64)-1026)   ===    (Math.pow(2,64)-1025)
true
```

In short, this means, that by using standard JS 64bit floating point numeric type, any value which is sufficiently high in abs terms will have its last bits truncated, and resulting 64-bit-wise operations will have inexact results.

To correct that we'd need to move away from using native numerical type, and do even more things manually (or find a bigint/bitwise lib for JS), and that is outside of the scope of this patch.

--------
Below: dump of my unredacted study of this issue, not really important, I'm pasting it here in case I have to review that again

```
curation estimator bug
  on Google Chrome 69.0.3497.100, Windows 10 x64
  in curation_calculator.html
  in function calculate()
  in approx_sqrt()

  approx_sqrt() can go wild for valid input data
  - this skews total-vote-weight estimations
  - this cases such vote to be treated as downvote and is ignored in final calculation

  probable cause:
  - bitwise semantic mistake when translating C/C++ code into JS

  example01:
    post '@offgridtinyhouse/exploring-the-ruins-of-an-abandoned-town'
    voter 'nfc'
    line: var max_weight = approx_sqrt(data.rshares_total + rshares) - approx_sqrt(data.rshares_total);
    expected: max_weight = 79219
    actual: max_weight = -10737470093
    fault: approx_sqrt(data.rshares_total + rshares)
          == approx_sqrt(790934409 + 10254681182)
          == approx_sqrt(11045615591)
          => -10737441641
    cmp with Math.sqrt = 105098.12363215625
    cmp with reimpl approx_sqrt in ruby = 107671

  example02:
    post '@offgridtinyhouse/exploring-the-ruins-of-an-abandoned-town'
    voter 'luxbet'
    line: var max_weight = approx_sqrt(data.rshares_total + rshares) - approx_sqrt(data.rshares_total);
    expected: max_weight = 24086
    actual: max_weight = 10737573398
    fault: approx_sqrt(data.rshares_total)
          == approx_sqrt(12694588943)
          => -10737435350
    cmp with Math.sqrt = 112670.26645481939
    cmp with reimpl approx_sqrt in ruby = 113962

analysis
  approx_sqrt(x=20506658865) (same post, vote of 'isitfunny')
    find_msb(x)             -> 34               OK
    msb_z                   -> 17               OK
    shiftleft64(1,msb_x)    -> 17179869184      OK
    shiftleft64(1,msb_z)    -> 131072           OK
    mantissa_mask           -> 17179869183      OK
    and64(x,mantissa_mask)  -> -968177615       WRONG, should be: 3326789681 (applying value correction for rest of function)
    and64(msb_x,1)          -> 0                OK
    shiftright64(mantissa_x, msb_x-msb_z)   -> 25381    OK
    or64(mantissa_z_hi, mantissa_z_lo)      -> 25381    OK
    shiftright64(or64(mantissa_z_hi..., 1)  -> 12690    OK
    or64(msb_z_bit, mantissa_z)             -> 143762   OK

    final max_weight        = 5714              OK (after 1 runtime value correction)

  and64(x=20506658865,y=17179869183)
    hi_lo(x)                -> {hi: 4, lo: 3326789681}  OK
    hi_lo(y)                -> {hi: 3, lo: 4294967295}  OK
    x.hi & y.hi             -> 0                        OK
    x.lo & y.lo             -> -968177615               WRONG, integer overflows to negatives
      *exploratory*
    y.lo                    -> 4294967295               OK
    y.lo + 1                -> 4294967296               OK
    y.lo - 1                -> 4294967294               OK
    y.lo | 1                -> -1                       seems bitwise ops return SIGNED!

  patch for and64:
    hi = x.hi & y.hi;
    lo = x.lo & y.lo;
    if(hi<0) hi = hi >>> 0
    if(lo<0) lo = lo >>> 0
```